### PR TITLE
Don't ignore MemUtil WriteToPtr count parameter

### DIFF
--- a/SharpVk/SharpVk/MemUtil.cs
+++ b/SharpVk/SharpVk/MemUtil.cs
@@ -49,7 +49,7 @@ namespace SharpVk
             if (count > 0)
             {
                 int elementSize = (int)SizeOf<T>();
-                int transferSize = elementSize * value.Length;
+                int transferSize = elementSize * count;
 
                 byte* pointer = (byte*)dest.ToPointer();
 

--- a/SharpVk/SharpVk/MemUtil.cs
+++ b/SharpVk/SharpVk/MemUtil.cs
@@ -50,8 +50,10 @@ namespace SharpVk
             {
                 int elementSize = (int)SizeOf<T>();
                 int transferSize = elementSize * count;
+                int startOffset = elementSize * startIndex;
 
                 byte* pointer = (byte*)dest.ToPointer();
+                pointer += startOffset;
 
                 var handle = GCHandle.Alloc(value, GCHandleType.Pinned);
 


### PR DESCRIPTION
In VertexBuffer sample this method called with **_count_** set to array length, so as I understand it should count number of copied vertices from array, but in method itself its only compared to zero and then all array is copied ignoring **_count_** parameter.